### PR TITLE
Print full path to config file in generate-config

### DIFF
--- a/barbari/commands/generate_config.py
+++ b/barbari/commands/generate_config.py
@@ -22,15 +22,18 @@ class Command(BaseCommand):
         os.makedirs(
             config.get_user_config_dir(), exist_ok=True
         )
+
+        final_path = os.path.join(
+                config.get_user_config_dir(),
+                final_path,
+            )
+
         shutil.copyfile(
             os.path.join(
                 config.get_default_config_dir(),
                 self.DEFAULT_CONFIG,
             ),
-            os.path.join(
-                config.get_user_config_dir(),
-                final_path,
-            )
+            final_path
         )
 
         self.console.print(

--- a/barbari/commands/generate_config.py
+++ b/barbari/commands/generate_config.py
@@ -19,21 +19,19 @@ class Command(BaseCommand):
     def handle(self) -> None:
         final_path = f"{self.options.name}.yaml"
 
-        os.makedirs(
-            config.get_user_config_dir(), exist_ok=True
-        )
+        os.makedirs(config.get_user_config_dir(), exist_ok=True)
 
         final_path = os.path.join(
-                config.get_user_config_dir(),
-                final_path,
-            )
+            config.get_user_config_dir(),
+            final_path,
+        )
 
         shutil.copyfile(
             os.path.join(
                 config.get_default_config_dir(),
                 self.DEFAULT_CONFIG,
             ),
-            final_path
+            final_path,
         )
 
         self.console.print(


### PR DESCRIPTION
Previously, it would print this:
```
$ barbari generate-config test1
Configuration 'test1' written to 'test1.yaml'.
```
That makes it seem like the file `test1.yaml` was generated in current working directory, when in fact it wasn't.

Now it looks like this:
```
$ barbari generate-config test2
Configuration 'test2' written to '/home/ondra/.config/barbari/configs/test2.yaml'.
```