### PR TITLE
Fix wrong yaml indentation reported by yamllint

### DIFF
--- a/barbari/configs/coddingtonbear.yaml
+++ b/barbari/configs/coddingtonbear.yaml
@@ -7,49 +7,49 @@ description: |
 drill:
   voltera:
     sizes:
-    - 1.5
+      - 1.5
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 1.0
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
-    - type: cnc_drill
-      params:
-        tool_size: 1.5
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.0
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.5
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
   minimill:
     min_size: 0.6
     max_size: 1.0
     specs:
-    - type: mill_slots
-      params:
-        tool_size: 0.6
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 25
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_slots
+        params:
+          tool_size: 0.6
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 25
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2
 slot:
   small:
     min_size: 0.6
     max_size: 1.0
     specs:
-    - type: mill_slots
-      params:
-        tool_size: 0.6
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 25
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_slots
+        params:
+          tool_size: 0.6
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 25
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2
 include:
   - ./default_isolation_routing.yaml
   - ./default_alignment_holes.yaml

--- a/barbari/configs/copper_wire_vias.yaml
+++ b/barbari/configs/copper_wire_vias.yaml
@@ -2,12 +2,12 @@ drill:
   via:
     max_size: 0.4
     sizes:
-    - 0.4
+      - 0.4
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 0.4
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 0.4
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000

--- a/barbari/configs/drilled_04_10.yaml
+++ b/barbari/configs/drilled_04_10.yaml
@@ -3,10 +3,10 @@ drill:
     min_size: 0.4
     max_size: 1.0
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 1.0
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.0
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000

--- a/barbari/configs/drilled_pth_04_11.yaml
+++ b/barbari/configs/drilled_pth_04_11.yaml
@@ -3,17 +3,17 @@ drill:
     min_size: 0.4
     max_size: 1.1
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 1.0
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
-    - type: cnc_drill
-      params:
-        tool_size: 1.5
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.0
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.5
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000

--- a/barbari/configs/example.yaml
+++ b/barbari/configs/example.yaml
@@ -23,49 +23,49 @@ drill:
   via:
     max_size: 0.4
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 0.4
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 0.4
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
   drilled:
     min_size: 0.4
     max_size: 1.0
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 1.0
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.0
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
   milled:
     min_size: 1.0
     specs:
-    - type: mill_holes
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_holes
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2
 slot:
   large:
     min_size: 1.0
     specs:
-    - type: mill_slots
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_slots
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2
 edge_cuts:
   tool_size: 1.5
   margin: 0

--- a/barbari/configs/milled_10.yaml
+++ b/barbari/configs/milled_10.yaml
@@ -2,12 +2,12 @@ drill:
   milled:
     min_size: 1.0
     specs:
-    - type: mill_holes
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_holes
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2

--- a/barbari/configs/milled_11.yaml
+++ b/barbari/configs/milled_11.yaml
@@ -2,12 +2,12 @@ drill:
   milled:
     min_size: 1.1
     specs:
-    - type: mill_holes
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_holes
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2

--- a/barbari/configs/slots_10.yaml
+++ b/barbari/configs/slots_10.yaml
@@ -2,12 +2,12 @@ slot:
   large:
     min_size: 1.0
     specs:
-    - type: mill_slots
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_slots
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2

--- a/readme.md
+++ b/readme.md
@@ -115,36 +115,36 @@ drill:
   via:
     max_size: 0.4
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 0.4
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 0.4
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
   drilled:
     min_size: 0.4
     max_size: 1.0
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 1.0
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.0
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
   milled:
     min_size: 1.0
     specs:
-    - type: mill_holes
-      params:
-        tool_size: 1
-        cut_z: -2.5
-        travel_z: 2
-        feed_rate: 100
-        spindle_speed: 12000
-        multi_depth: true
-        depth_per_pass: 0.2
+      - type: mill_holes
+        params:
+          tool_size: 1
+          cut_z: -2.5
+          travel_z: 2
+          feed_rate: 100
+          spindle_speed: 12000
+          multi_depth: true
+          depth_per_pass: 0.2
 ```
 
 You'll see from the above that any holes up to 0.4mm in diameter will be drilled using the `via` processes (called `specs` here) -- drilling with a 0.4mm drill, any drills from 0.4mm to 1.0mm in size will be drilled using a 1.0mm drill bit, and anything bigger than 1.0mm will be milled using a 1.0mm end mill.  You might
@@ -158,20 +158,20 @@ In some situations -- mostly around drilling large holes -- you might need a par
     min_size: 0.4
     max_size: 1.1
     specs:
-    - type: cnc_drill
-      params:
-        tool_size: 0.7
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
-    - type: cnc_drill
-      params:
-        tool_size: 1.5
-        drill_z: -2.5
-        travel_z: 2
-        feed_rate: 50
-        spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 0.7
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
+      - type: cnc_drill
+        params:
+          tool_size: 1.5
+          drill_z: -2.5
+          travel_z: 2
+          feed_rate: 50
+          spindle_speed: 12000
 ```
 
 The above configuration will drill any holes from 0.4mm to 1.1mm in diameter twice -- first with a 0.7mm drill, and then afterward with a 1.5mm drill.


### PR DESCRIPTION
The files weren't invalid, but I think it's better to use a linter to keep a consistent style. Feel free to close this PR if you disagree.