### PR TITLE
Fix invalid `pass_overlap` in exaple.yaml

### DIFF
--- a/barbari/configs/example.yaml
+++ b/barbari/configs/example.yaml
@@ -12,6 +12,7 @@ alignment_holes:
 isolation_routing:
   tool_size: 0.18
   width: 1
+  passes: 2
   pass_overlap: 0.5
   cut_z: -0.2
   travel_z: 2

--- a/barbari/configs/example.yaml
+++ b/barbari/configs/example.yaml
@@ -12,7 +12,7 @@ alignment_holes:
 isolation_routing:
   tool_size: 0.18
   width: 1
-  pass_overlap: 1
+  pass_overlap: 0.5
   cut_z: -0.2
   travel_z: 2
   feed_rate: 200

--- a/readme.md
+++ b/readme.md
@@ -97,7 +97,7 @@ Example:
 isolation_routing:
   tool_size: 0.18
   width: 1
-  pass_overlap: 1
+  pass_overlap: 0.5
   cut_z: -0.2
   travel_z: 2
   feed_rate: 200

--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Example:
 isolation_routing:
   tool_size: 0.18
   width: 1
+  passes: 2
   pass_overlap: 0.5
   cut_z: -0.2
   travel_z: 2


### PR DESCRIPTION
According to FlatCAM, it should be a float between 0 and 99.9999:
```
> help isolate
Creates isolation routing Geometry for the specified Gerber object.
> isolate name [-dia <float>] [-passes <int>] [-overlap <float>] [-combine <str>] [-outname <str>] [-follow <str>] [-iso_type <int>]
	name <str>: Name of the Gerber source object to be isolated. Required.
	[-dia <float>: Tool diameter.]
	[-passes <int>: Passes of tool width.]
	[-overlap <float>: Percentage of tool diameter to overlap current pass over previous pass. Float [0, 99.9999]
E.g: for a 25% from tool diameter overlap use -overlap 25]
...
```

Also, `example.yaml` config didn't work because it was missing `passes` under `isolation_routing`.